### PR TITLE
show '/*' (specfic resources) in access list

### DIFF
--- a/src/Services/Salesforce.php
+++ b/src/Services/Salesforce.php
@@ -170,10 +170,11 @@ class Salesforce extends BaseDbService
 
         $result = $this->getSObjects(true);
         foreach ($result as $name) {
-            $name = Schema::RESOURCE_NAME . '/' . $name;
+            $name = Schema::RESOURCE_NAME . '/' . $name . '/';
             $access = $this->getPermissions($name);
             if (!empty($access)) {
-                $resources[] = $name;
+		$resources[] = $name;
+		$resources[] = $name . '*';
             }
         }
 
@@ -185,10 +186,11 @@ class Salesforce extends BaseDbService
         }
 
         foreach ($result as $name) {
-            $name = Table::RESOURCE_NAME . '/' . $name;
+            $name = Table::RESOURCE_NAME . '/' . $name . '/';
             $access = $this->getPermissions($name);
             if (!empty($access)) {
-                $resources[] = $name;
+		$resources[] = $name;
+		$resources[] = $name . '*';
             }
         }
 


### PR DESCRIPTION
Salesforce services access list was not showing _schema/{table name}/* and _table/{table name}/*.
Also _schema/{table name} and _table/{table name} did not end with a trailing slash, while other DreamFactory database access lists did. This PR addresses both items. I followed the style convention in dreamfactory/df-database for this.