### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 .idea
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ This is an add on to the DreamFactory Core library and requires the [df-core rep
 This code is governed by a commercial license. To use it, you must follow the [terms of use](http://dreamfactory.com/termsofuse), refer to the LICENSE file.
 
 This repo includes some modified SoapClient code originally from [phpforce/soap-client](https://github.com/phpforce/soap-client).
+
+
+## Overview
+
+DreamFactory is a secure, self-hosted enterprise data access platform that provides governed API access to any data source, connecting enterprise applications and on-prem LLMs with role-based access and identity passthrough.

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-database":      "~1.0",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-database": "~1.4",
     "socialiteproviders/salesforce": "^4.1"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/tests/SalesforceTest.php
+++ b/tests/SalesforceTest.php
@@ -27,7 +27,7 @@ class SalesforceTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCa
      */
     protected $service = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class SalesforceTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCa
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }


### PR DESCRIPTION
## Summary

Wave 3 of the L11 -> L13 upgrade campaign for `df-salesforce`.

- composer.json bumped to the campaign-standard L13 dep matrix: `php ^8.3`, `laravel/helpers ^1.8`, `laravel/framework ^13.7` (dev), `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`.
- `dreamfactory/df-database` constraint bumped from `~1.0` -> `~1.4` to align with the L13-upgraded df-database (Wave 1).
- `setUp()`/`tearDown()` in `tests/SalesforceTest.php` now declare `: void` for PHPUnit 11 LSP compliance.
- `.gitignore` adds `.phpunit.result.cache`.

## Source-change scope

**Zero src/ changes.** Survey confirmed the package contains none of the L13 invariant fingerprints:

- no `Illuminate\Foundation\Bus\DispatchesJobs` trait (removed in L11)
- no `setupBeforeClass` typos (PHPUnit 11 case-sensitivity)
- no `Fruitcake\Cors\CorsService` imports
- no `Illuminate\Database\Connection` / `Query\Builder` / `Grammar` extensions
- no anonymous `ConnectionInterface` stubs in tests (the L13 `select()`/`cursor()` 4th-arg signature change does not apply)
- no `getDates()` / `HasAttributes` direct trait usage
- no route registrations / middleware groups
- no `Route::prependMiddlewareToGroup('web', ...)` patterns

The Salesforce SDK chain (`socialiteproviders/salesforce ^4.1` -> `socialiteproviders/manager ~4.0` -> `laravel/socialite ^5.27`) is already L13-compatible: `laravel/socialite v5.27.0` declares `illuminate/http ^6|^7|^8|^9|^10|^11|^12|^13`.

## Stage 1 — Isolated install + autoload smoke

Path-repo aliases for df-core 1.0.99, df-system 0.6.99, df-database 1.4.99, df-oauth 0.16.99 (df-oauth path-repo added because df-salesforce historically references `DreamFactory\Core\OAuth\*` classes without declaring the dep in its own composer.json — pre-existing tech debt, not a regression).

- `composer validate --strict`: pass
- `composer install`: resolves under L13.7
- `php -l` across `src/` + `tests/`: clean
- Class-existence smoke: 18/18 namespaced classes load
- Helper polyfills (`array_get`, `camel_case`, `array_except`, `array_get_bool`): present

## Stage 2 — Host-app shift-173254 smoke

Standard sibling-strip (`df-mongo-logs`, `df-git`, `df-mcp-server`) plus `MongoDB\Laravel\MongoDBServiceProvider::class` commented in `config/app.php`. **df-oauth was NOT stripped** because df-salesforce hard-references `BaseOAuthService` / `DfOAuthTwoProvider` / `OAuthConfig` / `OAuthTokenMap`. Path-repos for df-core/df-system/df-database/df-oauth/df-salesforce on `shift/laravel-13`.

- `composer install --no-dev`: resolves; `package:discover` passes for all 21 listed packages (df-salesforce included).
- Autoload smoke: 21/21 classes load — including `SocialiteProviders\SalesForce\Provider`, `SocialiteProviders\Manager\SocialiteWasCalled`, and `DreamFactory\Core\OAuth\Services\BaseOAuthService`.
- ServiceProvider reflects as a direct subclass of `Illuminate\Support\ServiceProvider`; `register()` and `boot()` methods present.
- Inheritance chains: `Components\SalesforceProvider extends SocialiteProviders\SalesForce\Provider` (uses `DfOAuthTwoProvider` trait), `Services\Salesforce extends DreamFactory\Core\Database\Services\BaseDbService`, `Services\SalesforceOAuth extends DreamFactory\Core\OAuth\Services\BaseOAuthService` — all resolve.

## New invariants discovered

1. **df-salesforce <-> df-oauth coupling is undeclared** — `src/Services/SalesforceOAuth.php`, `src/Services/Salesforce.php`, `src/ServiceProvider.php`, and `src/Components/SalesforceProvider.php` import `DreamFactory\Core\OAuth\*` classes but `composer.json` has never declared `dreamfactory/df-oauth` as a require. Pre-existing on master; deliberately preserved on this PR to avoid changing semantics. Future cleanup should add the missing dep.
2. **PHPUnit 11 fixture method signatures**: `setUp()` / `tearDown()` without `: void` would crash on phpunit boot under PHPUnit 11. Wave 3+ packages with similar fixture method drift need this same patch — applies regardless of whether the test file is exercisable in Stage 1 (ours is host-bootstrap-deferred).
3. **Salesforce SDK chain is L13-clean already**: `laravel/socialite ^5.27` lists `illuminate/http ^13.0`, `socialiteproviders/manager ~4.0` doesn't pin illuminate at all, `socialiteproviders/salesforce ^4.1` doesn't pin Laravel. No SDK upgrade needed.

## Blockers / follow-ups

- None blocking the merge.
- df-database needs a `~1.4.x` tag on its `shift/laravel-13` head before the host app picks up df-salesforce's L13 line via Packagist. Same constraint Wave 2 (df-sqldb) noted.

## Test plan

- [ ] After df-database, df-oauth, and df-salesforce L13 PRs all merge, tag each at the campaign-agreed minor and re-run host-app `composer install` against shift-173254 without path-repos.
- [ ] Functional test against a real Salesforce sandbox: create `salesforce_db` service via API, list SObjects, exercise `_table/Account` CRUD.
- [ ] Functional test against `oauth_salesforce` service: complete the OAuth2 redirect handshake and confirm `OAuthTokenMap` rows persist.
- [ ] Confirm `socialiteproviders/manager 4.9.2` event listener wiring still works under L13's event dispatcher.