### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 .idea
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-database":      "~1.0",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-database": "~1.4",
     "socialiteproviders/salesforce": "^4.1"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Resources/Table.php
+++ b/src/Resources/Table.php
@@ -110,6 +110,19 @@ class Table extends BaseNoSqlDbTableResource
         $offset = intval(Arr::get($extras, ApiOptions::OFFSET, 0));
         $limit = intval(Arr::get($extras, ApiOptions::LIMIT, 0));
 
+        // Validate identifiers before concatenation. The filter parameter
+        // is, by design, a SOQL WHERE fragment chosen by the caller, so it
+        // is not validated here (Salesforce's REST query endpoint only
+        // executes one SOQL statement per request). However the table and
+        // field-list identifiers must match the SF identifier shape; a
+        // payload with semicolons / SOQL keywords / quotes in a position
+        // that should be a bare identifier would break the assumption.
+        self::assertSafeSoqlIdentifier($table, 'table');
+        self::assertSafeSoqlFieldList($fields);
+        if (!empty($order)) {
+            self::assertSafeSoqlFieldList($order);
+        }
+
         // build query string either count or fields
         if ($countOnly === true) {
             $queryStr = 'SELECT COUNT() FROM ' . $table;
@@ -133,6 +146,54 @@ class Table extends BaseNoSqlDbTableResource
         }
 
         return $queryStr;
+    }
+
+    /**
+     * Validate a value that will be interpolated as a SOQL identifier
+     * (table or single field name).
+     *
+     * @throws \DreamFactory\Core\Exceptions\BadRequestException
+     */
+    public static function assertSafeSoqlIdentifier(string $value, string $context = 'identifier'): void
+    {
+        // Salesforce object/field names: alphanumeric + underscore, may end
+        // in __c (custom) or contain dot for relationship traversal
+        // (e.g., Account.Owner.Name). Aggregate aliases use AS - allow
+        // optional " ASC"/" DESC" suffix when called from order context;
+        // those are handled by assertSafeSoqlFieldList.
+        if ($value === '' || preg_match('/^[A-Za-z][A-Za-z0-9_.]*$/', $value) !== 1) {
+            throw new \DreamFactory\Core\Exceptions\BadRequestException(
+                "Invalid SOQL {$context}: must match Salesforce identifier syntax."
+            );
+        }
+    }
+
+    /**
+     * Validate a comma-separated list of SOQL identifiers (with optional
+     * ASC/DESC qualifier when used in ORDER BY).
+     *
+     * @throws \DreamFactory\Core\Exceptions\BadRequestException
+     */
+    public static function assertSafeSoqlFieldList(string $list): void
+    {
+        $parts = array_map('trim', explode(',', $list));
+        foreach ($parts as $part) {
+            if ($part === '') {
+                continue;
+            }
+            // Allow trailing ASC/DESC and "NULLS FIRST"/"NULLS LAST" tokens.
+            $tokens = preg_split('/\s+/', $part);
+            $identifier = array_shift($tokens) ?? '';
+            self::assertSafeSoqlIdentifier($identifier, 'field');
+            foreach ($tokens as $tok) {
+                $upper = strtoupper($tok);
+                if (!in_array($upper, ['ASC', 'DESC', 'NULLS', 'FIRST', 'LAST'], true)) {
+                    throw new \DreamFactory\Core\Exceptions\BadRequestException(
+                        "Invalid SOQL field-list token: {$tok}"
+                    );
+                }
+            }
+        }
     }
 
     protected function getFieldsInfo($table)

--- a/tests/SalesforceTest.php
+++ b/tests/SalesforceTest.php
@@ -27,7 +27,7 @@ class SalesforceTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCa
      */
     protected $service = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class SalesforceTest extends \DreamFactory\Core\Database\Testing\DbServiceTestCa
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/Security/SoqlIdentifierValidationTest.php
+++ b/tests/Security/SoqlIdentifierValidationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace DreamFactory\Core\Salesforce\Tests\Security;
+
+use DreamFactory\Core\Exceptions\BadRequestException;
+use DreamFactory\Core\Salesforce\Resources\Table;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: Salesforce Table::buildConditionsStr() must validate $table and
+ * $fields as SOQL identifiers before concatenation into the query string.
+ *
+ * The filter parameter (`?filter=...`) is a SOQL WHERE fragment by design,
+ * and Salesforce's REST query endpoint only executes one statement per
+ * request, so traditional stacked-query injection is not the threat. The
+ * threat is identifier-position injection — a payload arriving where DF
+ * expects a bare object/field name that smuggles SOQL keywords or breaks
+ * the syntax assumption.
+ *
+ * After the fix, both identifier slots are validated against
+ * `^[A-Za-z][A-Za-z0-9_.]*$` (the Salesforce object/field shape including
+ * relationship dots and `__c` custom suffix). Field lists optionally allow
+ * `ASC`/`DESC`/`NULLS FIRST`/`NULLS LAST` qualifiers when used in ORDER BY.
+ */
+class SoqlIdentifierValidationTest extends TestCase
+{
+    /**
+     * @dataProvider validIdentifierProvider
+     */
+    public function testAcceptsValidSoqlIdentifier(string $value): void
+    {
+        Table::assertSafeSoqlIdentifier($value);
+        $this->assertTrue(true);
+    }
+
+    public static function validIdentifierProvider(): array
+    {
+        return [
+            'standard object'  => ['Account'],
+            'custom object'    => ['MyCustom__c'],
+            'relationship'     => ['Account.Owner.Name'],
+            'with digits'      => ['Object123'],
+            'underscore'       => ['my_field'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidIdentifierProvider
+     */
+    public function testRejectsInvalidSoqlIdentifier(string $value): void
+    {
+        $this->expectException(BadRequestException::class);
+        Table::assertSafeSoqlIdentifier($value);
+    }
+
+    public static function invalidIdentifierProvider(): array
+    {
+        return [
+            'with semicolon'   => ['Account; SELECT'],
+            'with space'       => ['Account WHERE 1=1'],
+            'with quote'       => ["Account' OR '1"],
+            'with paren'       => ['Account)'],
+            'with dash'        => ['Acc-ount'],
+            'starts with number' => ['1Account'],
+            'empty'            => [''],
+            'only whitespace'  => ['   '],
+            'with newline'     => ["Account\nSELECT"],
+            'starts with dot'  => ['.Account'],
+        ];
+    }
+
+    public function testFieldListAcceptsBareList(): void
+    {
+        Table::assertSafeSoqlFieldList('Id, Name, Owner.Name');
+        $this->assertTrue(true);
+    }
+
+    public function testFieldListAcceptsOrderByQualifiers(): void
+    {
+        Table::assertSafeSoqlFieldList('CreatedDate DESC, Name ASC');
+        Table::assertSafeSoqlFieldList('Name ASC NULLS FIRST');
+        $this->assertTrue(true);
+    }
+
+    public function testFieldListRejectsInjectionPayload(): void
+    {
+        $this->expectException(BadRequestException::class);
+        Table::assertSafeSoqlFieldList("Id, Name'; DELETE FROM");
+    }
+
+    public function testCallSiteValidatesTableAndFields(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Resources/Table.php';
+        $this->assertFileExists($sourcePath);
+        $contents = file_get_contents($sourcePath);
+
+        $this->assertMatchesRegularExpression(
+            '/assertSafeSoqlIdentifier\s*\(\s*\$table/',
+            $contents,
+            'buildConditionsStr() must validate $table'
+        );
+        $this->assertMatchesRegularExpression(
+            '/assertSafeSoqlFieldList\s*\(\s*\$fields/',
+            $contents,
+            'buildConditionsStr() must validate $fields'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
